### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -25,7 +25,7 @@ function isSpecFile(path) {
 function isBuiltFile(path) {
   return isJsFile(path) &&
          builtPaths.reduce(function(keep, bp) {
-           return keep || (path.substr(0, bp.length) === bp);
+           return keep || (path.slice(0, bp.length) === bp);
          }, false);
 }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -112,7 +112,7 @@ export class AppComponent extends GraphExplorerComponent implements OnInit, Afte
             }
         }
 
-        const hash = location.hash.substr(1);
+        const hash = location.hash.slice(1);
         if (hash.includes('mode')) {
             const mode = 'canary';
             localStorage.setItem('GRAPH_MODE', JSON.stringify(mode));

--- a/src/app/history/history-panel.component.ts
+++ b/src/app/history/history-panel.component.ts
@@ -70,7 +70,7 @@ export class HistoryPanelComponent extends GraphExplorerComponent implements OnI
     public exportQuery(query: IGraphApiCall) {
       const blob = new Blob([query.har], { type: 'text/json' });
 
-      const url = query.requestUrl.substr(8).split('/');
+      const url = query.requestUrl.slice(8).split('/');
       url.pop(); // Removes leading slash
 
       const filename = `${url.join('_')}.har`;

--- a/src/app/response-handlers.ts
+++ b/src/app/response-handlers.ts
@@ -47,14 +47,14 @@ export function handleTextResponse(results) {
 }
 
 export function isImageResponse(contentType: string) {
-    return contentType === 'application/octet-stream' || contentType.substr(0, 6) === 'image/';
+    return contentType === 'application/octet-stream' || contentType.slice(0, 6) === 'image/';
 }
 
 export function getContentType(headers: Headers) {
     const full = headers.get('content-type');
     const delimiterPos = full.indexOf(';');
     if (delimiterPos !== -1) {
-        return full.substr(0, delimiterPos);
+        return full.slice(0, delimiterPos);
     } else {
         return full;
     }
@@ -143,7 +143,7 @@ const formatXml = (xml) => {
             return results;
         })()).join('');
         if (fromTo === 'opening->closing') {
-            formatted = formatted.substr(0, formatted.length - 1) + ln + '\n';
+            formatted = formatted.slice(0, -1) + ln + '\n';
         } else {
             formatted += padding + ln + '\n';
         }


### PR DESCRIPTION
## Overview

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.


## Testing Instructions

I tested the return of each statement to make sure it's still the same as before